### PR TITLE
nop: diagnose #55

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ This agent allows you to instrument Flutter apps with help of native New Relic A
 agents. The New Relic SDKs collect crashes, network traffic, and other information for hybrid apps
 using native components.
 
-
 ## Features
 
 * Capture Dart errors
@@ -446,4 +445,5 @@ If you would like to contribute to this project, review [these guidelines](./CON
 
 newrelic-flutter-agent is licensed under the [Apache 2.0](https://apache.org/licenses/LICENSE-2.0.txt)
 License.
+
 > newrelic-flutter-agent also uses source code from third-party libraries. Full details on which libraries are used and the terms under which they are licensed can be found in the third-party notices document.


### PR DESCRIPTION
Remove white space to test https://github.com/newrelic/newrelic-flutter-agent/issues/55#user-content--readme-starts-with-community-plus-header

This is probably caused by evaluating the new workflow in the CI using the old workflow. The new workflow can’t be permitted to run until it has been checked, and the check uses the old code.

To test that diagnosis:
1. Nisarg merges the last PR
2. I submit a new PR that does nothing (this one)
3. We see if the error goes away