### PR TITLE
Fix NewRelicNavigationObserver class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.0.9
 * Resolved NewRelicNavigationObserver issue for Go Router.
 
-## 1.0.9
+## 1.0.8
 * Updated the native iOS agent to version 7.4.10.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 1.0.8
+## 1.0.9
+* Resolved NewRelicNavigationObserver issue for Go Router.
+
+## 1.0.9
 * Updated the native iOS agent to version 7.4.10.
 
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Install NewRelic plugin into your dart project by adding it to dependecies in yo
 ```yaml
 
 dependencies:
-  newrelic_mobile: 1.0.8
+  newrelic_mobile: 1.0.9
   
 ```
 

--- a/android/src/main/kotlin/com/newrelic/newrelic_mobile/NewrelicMobilePlugin.kt
+++ b/android/src/main/kotlin/com/newrelic/newrelic_mobile/NewrelicMobilePlugin.kt
@@ -100,9 +100,9 @@ class NewrelicMobilePlugin : FlutterPlugin, MethodCallHandler {
                     applicationToken
                 ).withLoggingEnabled(loggingEnabled!!)
                     .withLogLevel(5)
-                    .withApplicationFramework(ApplicationFramework.Flutter, "1.0.8").start(context)
+                    .withApplicationFramework(ApplicationFramework.Flutter, "1.0.9").start(context)
                 NewRelic.setAttribute("DartVersion", dartVersion)
-                StatsEngine.get().inc("Supportability/Mobile/Android/Flutter/Agent/1.0.8");
+                StatsEngine.get().inc("Supportability/Mobile/Android/Flutter/Agent/1.0.9");
                 result.success("Agent Started")
             }
             "setUserId" -> {

--- a/ios/newrelic_mobile.podspec
+++ b/ios/newrelic_mobile.podspec
@@ -9,7 +9,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'newrelic_mobile'
-  s.version          = '1.0.8'
+  s.version          = '1.0.9'
   s.summary          = 'Flutter plugin for NewRelic Mobile.'
   s.description      = <<-DESC
 Flutter plugin for NewRelic Mobile.

--- a/lib/newrelic_mobile.dart
+++ b/lib/newrelic_mobile.dart
@@ -38,7 +38,7 @@ class NewrelicMobile {
       await NewrelicMobile.instance.startAgent(config);
       runApp();
       await NewrelicMobile.instance
-          .setAttribute("Flutter Agent Version", "1.0.8");
+          .setAttribute("Flutter Agent Version", "1.0.9");
     }, (Object error, StackTrace stackTrace) {
       NewrelicMobile.instance.recordError(error, stackTrace);
       FlutterError.presentError(

--- a/lib/newrelic_navigation_observer.dart
+++ b/lib/newrelic_navigation_observer.dart
@@ -5,7 +5,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:newrelic_mobile/newrelic_mobile.dart';
-import 'package:go_router/go_router.dart';
 
 const breadCrumbName = 'navigation';
 
@@ -14,16 +13,7 @@ class NewRelicNavigationObserver extends RouteObserver<PageRoute<dynamic>> {
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPop(route, previousRoute);
     if (route is PageRoute && previousRoute is PageRoute) {
-      if (route.settings is MaterialPage ||
-          route.settings is CustomTransitionPage) {
-        var goRoute = route.settings;
-
-        var goPreviousRoute = previousRoute.settings;
-
-        _addGoRouterBreadcrumb('didPop', goRoute, goPreviousRoute);
-      } else {
-        _addBreadcrumb('didPop', route.settings, previousRoute.settings);
-      }
+      _addBreadcrumb('didPop', route.settings, previousRoute.settings);
     }
   }
 
@@ -32,20 +22,7 @@ class NewRelicNavigationObserver extends RouteObserver<PageRoute<dynamic>> {
     super.didPush(route, previousRoute);
 
     if (route is PageRoute) {
-      if (route.settings is MaterialPage ||
-          route.settings is CustomTransitionPage) {
-        var goRoute = route.settings;
-
-        var goPreviousRoute;
-
-        if (previousRoute != null) {
-          goPreviousRoute = previousRoute.settings;
-        }
-
-        _addGoRouterBreadcrumb('didPush', goPreviousRoute, goRoute);
-      } else {
-        _addBreadcrumb('didPush', previousRoute?.settings, route.settings);
-      }
+      _addBreadcrumb('didPush', previousRoute?.settings, route.settings);
     }
   }
 
@@ -53,16 +30,7 @@ class NewRelicNavigationObserver extends RouteObserver<PageRoute<dynamic>> {
   void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
     super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
     if (newRoute is PageRoute && oldRoute is PageRoute) {
-      if (newRoute.settings is MaterialPage ||
-          newRoute.settings is CustomTransitionPage) {
-        var goRoute = newRoute.settings;
-
-        var goPreviousRoute = oldRoute.settings;
-
-        _addGoRouterBreadcrumb('didReplace', goPreviousRoute, goRoute);
-      } else {
-        _addBreadcrumb('didReplace', oldRoute.settings, newRoute.settings);
-      }
+      _addBreadcrumb('didReplace', oldRoute.settings, newRoute.settings);
     }
   }
 
@@ -76,24 +44,5 @@ class NewRelicNavigationObserver extends RouteObserver<PageRoute<dynamic>> {
     };
     NewrelicMobile.instance
         .recordBreadcrumb(breadCrumbName, eventAttributes: attributes);
-  }
-
-  void _addGoRouterBreadcrumb(
-      String methodType, dynamic fromRoute, dynamic toRoute) {
-    if (fromRoute is RouteSettings || toRoute is RouteSettings) {
-      var fromKey = fromRoute?.key.toString();
-      var toKey = toRoute?.key.toString();
-
-      Map<String, String?> attributes = <String, String?>{
-        'methodType': methodType,
-        // ignore: prefer_if_null_operators
-        'from': fromRoute?.child != null
-            ? ((fromRoute?.child.toString())! + '(' + fromKey! + ')')
-            : '/',
-        'to': (toRoute?.child.toString())! + '(' + toKey! + ')'
-      };
-      NewrelicMobile.instance
-          .recordBreadcrumb(breadCrumbName, eventAttributes: attributes);
-    }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: newrelic_mobile
 description: Flutter plugin for NewRelic Mobile. This plugin allows you to instrument Flutter apps with help of native New Relic Android and iOS agents.
-version: 1.0.8
+version: 1.0.9
 
 homepage: https://github.com/newrelic/newrelic-flutter-agent
 

--- a/test/newrelic_mobile_test.dart
+++ b/test/newrelic_mobile_test.dart
@@ -1035,7 +1035,7 @@ void main() {
 
     final Map<String, dynamic> attributeParams = <String, dynamic>{
       'name': 'Flutter Agent Version',
-      'value': '1.0.8',
+      'value': '1.0.9',
     };
 
     expect(methodCalLogs, <Matcher>[
@@ -1083,7 +1083,7 @@ void main() {
 
     final Map<String, dynamic> attributeParams = <String, dynamic>{
       'name': 'Flutter Agent Version',
-      'value': '1.0.8',
+      'value': '1.0.9',
     };
 
     expect(methodCalLogs, <Matcher>[


### PR DESCRIPTION
According to what was discussed in the https://github.com/newrelic/newrelic-flutter-agent/issues/68, it is only necessary to verify the names of the routeSettings type since the parameters of go router / router such as MaterialPage and CustomTransitionPage use the name parameter of the routeSettings as a child to send the information.

## Changed
- In the file lib/newrelic_navigation_observer.dart  the _addGoRouterBreadcrumb function is no longer used and only the _addBreadcrumb function is used.
- Readme.md file for the new version according to [semver](https://semver.org/)
- Update version in every file.