### PR TITLE
fix: Update test agent version to 1.1.16 in tests, fixing release

### DIFF
--- a/test/newrelic_mobile_test.dart
+++ b/test/newrelic_mobile_test.dart
@@ -53,7 +53,7 @@ void main() {
   const megaBytes = 100;
   const maxBufferTime = 300;
   const metricUnitBytes = "bytes";
-  const agentVersion = "1.1.15";
+  const agentVersion = "1.1.16";
   const traceData = {
     "id": "1",
     "guid": "2",


### PR DESCRIPTION
This PR fixes failing tests that were blocking the release of version 1.1.16.

### Changes
- Updated the agent version in `newrelic_mobile_test.dart` from 1.1.15 to 1.1.16 to match the current release version

### Motivation
The tests were using an outdated agent version constant (1.1.15), causing test failures and blocking the 1.1.16 release pipeline.

### Testing
- All unit tests should now pass with the correct agent version