### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,6 +8,10 @@ name: Repolinter Action
 # filtered in the "Test Default Branch" step.
 on: [ push, workflow_dispatch ]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   repolint:
     name: Run Repolinter


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-flutter-agent/security/code-scanning/1](https://github.com/newrelic/newrelic-flutter-agent/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/repolinter.yml` so the workflow does not rely on inherited defaults.

Best fix (without changing intended functionality): define workflow-level permissions with:
- `contents: read` (needed for checkout/repo metadata reads),
- `issues: write` (needed because `output_type: issue` indicates the action may create/update issues).

Place this block at the workflow root, after `on:` and before `jobs:` so it applies to all jobs unless overridden. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
