### PR TITLE
[NR-536393] fix: Default log level to WARN and respect logLevel arg on Android

### DIFF
--- a/android/src/main/kotlin/com/newrelic/newrelic_mobile/NewrelicMobilePlugin.kt
+++ b/android/src/main/kotlin/com/newrelic/newrelic_mobile/NewrelicMobilePlugin.kt
@@ -126,7 +126,7 @@ class NewrelicMobilePlugin : FlutterPlugin, MethodCallHandler {
                     NewRelic.withApplicationToken(
                         applicationToken
                     ).withLoggingEnabled(loggingEnabled!!)
-                        .withLogLevel(AgentLog.VERBOSE)
+                        .withLogLevel(LogLevel.valueOf(logLevel ?: "WARN").ordinal)
                         .withApplicationFramework(ApplicationFramework.Flutter, AGENT_VERSION)
                         .start(context)
                 } else {

--- a/ios/newrelic_mobile/Sources/newrelic_mobile/NewrelicMobilePlugin.swift
+++ b/ios/newrelic_mobile/Sources/newrelic_mobile/NewrelicMobilePlugin.swift
@@ -23,7 +23,7 @@ public class NewrelicMobilePlugin: NSObject, FlutterPlugin {
         case "startAgent":
             let applicationToken = args?["applicationToken"] as? String
             let dartVersion = args?["dartVersion"] as? String
-            var logLevel = NRLogLevelDebug.rawValue
+            var logLevel = NRLogLevelWarning.rawValue
             var collectorAddress: String? = nil
             var crashCollectorAddress: String? = nil
             
@@ -61,6 +61,7 @@ public class NewrelicMobilePlugin: NSObject, FlutterPlugin {
                 
                 let strToLogLevel = [
                     "ERROR": NRLogLevelError.rawValue,
+                    "WARN": NRLogLevelWarning.rawValue,
                     "WARNING": NRLogLevelWarning.rawValue,
                     "INFO": NRLogLevelInfo.rawValue,
                     "VERBOSE": NRLogLevelVerbose.rawValue,

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -45,5 +45,5 @@ class Config {
       this.newEventSystemEnabled = false,
       this.collectorAddress = "",
       this.crashCollectorAddress = "",
-      this.logLevel = LogLevel.DEBUG});
+      this.logLevel = LogLevel.WARN});
 }

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -19,6 +19,6 @@ void main() {
     expect(false, config.backgroundReportingEnabled);
     expect(false, config.newEventSystemEnabled);
     expect(true, config.collectorAddress.isEmpty);
-    expect(LogLevel.DEBUG, config.logLevel);
+    expect(LogLevel.WARN, config.logLevel);
   });
 }

--- a/test/newrelic_mobile_test.dart
+++ b/test/newrelic_mobile_test.dart
@@ -102,7 +102,7 @@ void main() {
     'distributedTracingEnabled': true,
     'collectorAddress': '',
     'crashCollectorAddress': '',
-    'logLevel': 'DEBUG'
+    'logLevel': 'WARN'
   };
 
   const boolValue = false;
@@ -1546,5 +1546,5 @@ void main() {
     ]);
   });
 
-  params['logLevel'] = 'DEBUG';
+  params['logLevel'] = 'WARN';
 }


### PR DESCRIPTION
Previously the Dart default was DEBUG, the Android default-collector path hardcoded VERBOSE (ignoring the configured level), and the iOS string map only recognized "WARNING" while the Dart enum sends "WARN".