### PR TITLE
fix: widen go_router constraint to allow 17.x

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   stack_trace: ^1.12.1
-  go_router: ">=7.0.0 <17.0.0"
+  go_router: ">=7.0.0 <18.0.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Associated issue

Closes #187

## What & Why

The published library depends on `go_router` only in `lib/newrelic_navigation_observer.dart`, and only to type-check two go_router page types (`CustomTransitionPage`, `NoTransitionPage`) for nicer navigation breadcrumb names. The previous upper bound of `<17.0.0` capped the entire dependency tree at go_router 16.x, blocking consumers from upgrading to go_router 17 (latest 17.3.0).

This widens the constraint to `<18.0.0` so apps on current Flutter/Dart SDKs can use the 17.x line.

```diff
-  go_router: ">=7.0.0 <17.0.0"
+  go_router: ">=7.0.0 <18.0.0"
```

## Callouts

- This is a stopgap. The root cause is that `go_router` is a forced runtime dependency used only for two `is` checks. go_router 18 will reintroduce the same wall and require another constraint bump. A follow-up should remove the dependency entirely (the two go_router page types extend `Page`/`RouteSettings`, so they degrade gracefully to the generic `settings.name` branch). Tracked separately.

## Test plan

- `flutter pub get` resolves cleanly in both the root package and `example/`.
- `flutter test` — navigation-observer tests pass. (Note: 6 pre-existing agent-start/config test failures exist on `main` unrelated to this change; this PR does not touch that code.)
- Constraint change is `pubspec.yaml`-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)